### PR TITLE
Fixed issues with JSON conversions for DriveService

### DIFF
--- a/FulcrumInjector/Properties/AssemblyInfo.cs
+++ b/FulcrumInjector/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Resources;
 [assembly: Guid("8cb7e832-9e90-4820-b225-0a4d59e6c0a2")]
 
 // Version information
-[assembly: AssemblyVersion("7.2.1.3000")]
-[assembly: AssemblyFileVersion("7.2.1.3000")]
+[assembly: AssemblyVersion("7.2.1.3001")]
+[assembly: AssemblyFileVersion("7.2.1.3001")]
 [assembly: NeutralResourcesLanguageAttribute( "en-US" )]
 

--- a/FulcrumInjector/Properties/AssemblyInfo.cs
+++ b/FulcrumInjector/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Resources;
 [assembly: Guid("8cb7e832-9e90-4820-b225-0a4d59e6c0a2")]
 
 // Version information
-[assembly: AssemblyVersion("7.2.1.3001")]
-[assembly: AssemblyFileVersion("7.2.1.3001")]
+[assembly: AssemblyVersion("7.2.1.3002")]
+[assembly: AssemblyFileVersion("7.2.1.3002")]
 [assembly: NeutralResourcesLanguageAttribute( "en-US" )]
 

--- a/FulcrumServices/FulcrumDriveService/JsonConverters/DriveServiceSettingsJsonConverter.cs
+++ b/FulcrumServices/FulcrumDriveService/JsonConverters/DriveServiceSettingsJsonConverter.cs
@@ -100,8 +100,8 @@ namespace FulcrumDriveService.JsonConverters
             bool ServiceEnabled = InputObject[nameof(DriveServiceSettings.ServiceEnabled)].Value<bool>();
             string GoogleDriveId = InputObject[nameof(DriveServiceSettings.GoogleDriveId)].Value<string>();
             string ApplicationName = InputObject[nameof(DriveServiceSettings.ApplicationName)].Value<string>();
-            DriveAuthorization DriveAuth = InputObject[nameof(DriveServiceSettings.ExplorerAuthorization)].Value<DriveAuthorization>();
-            DriveConfiguration DriveConfig = InputObject[nameof(DriveServiceSettings.ExplorerConfiguration)].Value<DriveConfiguration>();
+            DriveAuthorization DriveAuth = InputObject[nameof(DriveServiceSettings.ExplorerAuthorization)].ToObject<DriveAuthorization>();
+            DriveConfiguration DriveConfig = InputObject[nameof(DriveServiceSettings.ExplorerConfiguration)].ToObject<DriveConfiguration>();
 
             // Build a new output object using our pulled properties
             var OutputObject = new DriveServiceSettings()

--- a/FulcrumServices/FulcrumDriveService/Properties/AssemblyInfo.cs
+++ b/FulcrumServices/FulcrumDriveService/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Resources;
 [assembly: Guid("dfd619be-ce63-4e4d-9c23-17016793244c")]
 
 // Version information
-[assembly: AssemblyVersion("0.1.3.23")]
-[assembly: AssemblyFileVersion("0.1.3.23")]
+[assembly: AssemblyVersion("0.1.3.24")]
+[assembly: AssemblyFileVersion("0.1.3.24")]
 [assembly: NeutralResourcesLanguageAttribute( "en-US" )]
 

--- a/FulcrumServices/FulcrumDriveService/Properties/AssemblyInfo.cs
+++ b/FulcrumServices/FulcrumDriveService/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Resources;
 [assembly: Guid("dfd619be-ce63-4e4d-9c23-17016793244c")]
 
 // Version information
-[assembly: AssemblyVersion("0.1.3.24")]
-[assembly: AssemblyFileVersion("0.1.3.24")]
+[assembly: AssemblyVersion("0.1.3.25")]
+[assembly: AssemblyFileVersion("0.1.3.25")]
 [assembly: NeutralResourcesLanguageAttribute( "en-US" )]
 

--- a/FulcrumServices/FulcrumEmailService/Properties/AssemblyInfo.cs
+++ b/FulcrumServices/FulcrumEmailService/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Resources;
 [assembly: Guid("80cfe329-c459-49f1-bdb7-5063e2c2fc7b")]
 
 // Version information
-[assembly: AssemblyVersion("0.1.2.24")]
-[assembly: AssemblyFileVersion("0.1.2.24")]
+[assembly: AssemblyVersion("0.1.2.25")]
+[assembly: AssemblyFileVersion("0.1.2.25")]
 [assembly: NeutralResourcesLanguageAttribute( "en-US" )]
 

--- a/FulcrumServices/FulcrumService/Properties/AssemblyInfo.cs
+++ b/FulcrumServices/FulcrumService/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Resources;
 [assembly: Guid("9ed477f5-f3dc-4643-b7cb-e2fc3f33d652")]
 
 // Version information
-[assembly: AssemblyVersion("0.2.1.8")]
-[assembly: AssemblyFileVersion("0.2.1.8")]
+[assembly: AssemblyVersion("0.2.1.9")]
+[assembly: AssemblyFileVersion("0.2.1.9")]
 [assembly: NeutralResourcesLanguageAttribute( "en-US" )]
 

--- a/FulcrumServices/FulcrumUpdaterService/Properties/AssemblyInfo.cs
+++ b/FulcrumServices/FulcrumUpdaterService/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Resources;
 [assembly: Guid("5577927f-40b8-4ecb-b168-1cc06bd7b8f8")]
 
 // Version information
-[assembly: AssemblyVersion("0.1.2.25")]
-[assembly: AssemblyFileVersion("0.1.2.25")]
+[assembly: AssemblyVersion("0.1.2.26")]
+[assembly: AssemblyFileVersion("0.1.2.26")]
 [assembly: NeutralResourcesLanguageAttribute( "en-US" )]
 

--- a/FulcrumServices/FulcrumWatchdogService/Properties/AssemblyInfo.cs
+++ b/FulcrumServices/FulcrumWatchdogService/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Resources;
 [assembly: Guid("73615040-9704-4497-9aba-c5ef17f1d639")]
 
 // Version information
-[assembly: AssemblyVersion("0.1.2.24")]
-[assembly: AssemblyFileVersion("0.1.2.24")]
+[assembly: AssemblyVersion("0.1.2.25")]
+[assembly: AssemblyFileVersion("0.1.2.25")]
 [assembly: NeutralResourcesLanguageAttribute( "en-US" )]
 

--- a/FulcrumShim/res/fulcrum_shim.rc
+++ b/FulcrumShim/res/fulcrum_shim.rc
@@ -69,8 +69,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,12,17,3661
- PRODUCTVERSION 2,12,17,3661
+ FILEVERSION 2,12,17,3662
+ PRODUCTVERSION 2,12,17,3662
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -87,12 +87,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "MEAT Inc."
             VALUE "FileDescription", "FulcrumShim DLL used for debugging J2534 issues."
-            VALUE "FileVersion", "2.12.17.3661"
+            VALUE "FileVersion", "2.12.17.3662"
             VALUE "InternalName", "FulcrumShim.dll"
             VALUE "LegalCopyright", "Copyright (C) 2022 MEAT Inc."
             VALUE "OriginalFilename", "FulcrumShum.dll"
             VALUE "ProductName", "FulcrumShim"
-            VALUE "ProductVersion", "2.12.17.3661"
+            VALUE "ProductVersion", "2.12.17.3662"
         END
     END
     BLOCK "VarFileInfo"

--- a/FulcrumShim/res/fulcrum_shim.rc
+++ b/FulcrumShim/res/fulcrum_shim.rc
@@ -69,8 +69,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,12,17,3660
- PRODUCTVERSION 2,12,17,3660
+ FILEVERSION 2,12,17,3661
+ PRODUCTVERSION 2,12,17,3661
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -87,12 +87,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "MEAT Inc."
             VALUE "FileDescription", "FulcrumShim DLL used for debugging J2534 issues."
-            VALUE "FileVersion", "2.12.17.3660"
+            VALUE "FileVersion", "2.12.17.3661"
             VALUE "InternalName", "FulcrumShim.dll"
             VALUE "LegalCopyright", "Copyright (C) 2022 MEAT Inc."
             VALUE "OriginalFilename", "FulcrumShum.dll"
             VALUE "ProductName", "FulcrumShim"
-            VALUE "ProductVersion", "2.12.17.3660"
+            VALUE "ProductVersion", "2.12.17.3661"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
Drive service JSON conversion was failing due to issues with pulling encrypted values from the settings file. Fixed issues with those files and updated converters as needed.